### PR TITLE
Add SEO for AI to Top GEO Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ These can help you ride the AI wave to success rather than drown in it.
 - **[Searchify](https://searchify.ai)** – AI Visibility tracking and optimization platform built for SMBs. Pricing starts at $149/mo with optional full-service "done for you" add-ons.
 - **[Seerly (AIRO)](https://seerly.app/)** – AI search optimization platform.
 - **[Senso.ai](https://senso.ai)** – Detects content gaps and keeps your messaging consistent across AI surfaces; integrates with CMS for auto-publishing.
+- **[SEO for AI](https://getseoforai.com/)** – Free AI visibility checker plus a $197 remediation audit. Tracks ChatGPT, Perplexity, Claude, Gemini, and Google AI Overviews for small businesses.
 - **[Share of Model](https://www.jellyfish.com/en-us/news/jellyfish-launches-the-share-of-model-platform/)** – Jellyfish’s metric & platform measuring *proportional* mentions across LLMs—the “share of voice” for AI.
 - **[Tesseract](https://tesseract.adlift.com/)** – Tracks and analyses brand visibility across LLMs with AI Overview.
 - **[Trackerly.ai](https://trackerly.ai)** – Daily brand-mention tracker covering multiple LLMs in 20+ languages; auto-builds PDF or live-link reports for agencies and in-house teams.


### PR DESCRIPTION
Adding SEO for AI, a free AI visibility checker and paid audit service covering ChatGPT, Perplexity, Claude, Gemini, and Google AI Overviews.

- Product: https://getseoforai.com/
- Free checker: https://getseoforai.com/checker
- Positioned for small businesses rather than enterprise.

Entry placed alphabetically between Senso.ai and Share of Model.