### PR TITLE
Add AI Visibility Monitor (open-source Python GEO citation tracker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ These can help you ride the AI wave to success rather than drown in it.
 - **[AiCarma](https://aicarma.com)** – Daily *Visibility Score* and weekly email reports showing how Google AI Overviews, ChatGPT & Perplexity talk about your brand; 5-minute setup and flat $29 / mo after a 14-day trial.
 - **[AI Monitor](https://getaimonitor.com/)** – AI Monitor is the world’s first [open-source]([url](https://github.com/aio-guru/ai-monitor-first-open-source-free-ai-search-optimization-aio-answer-engine-optimization-aeo-tool/tree/main)) tool to track brand mentions in AI answers. See how ChatGPT, Google AI Overview, and Perplexity talk about you—and how you stack up against competitors.
 - **[AI Rank Tracker](https://airank.dejan.ai)** – DejanSEO’s experimental tool mining language-association graphs to show which entities LLMs most connect to your brand.
+- **[AI Visibility Monitor](https://github.com/WorkSmartAI-alt/ai-visibility-monitor)** – Open-source Python toolkit for tracking ChatGPT, Claude, and Perplexity citations of a given domain. Self-hosted, MIT licensed.
 - **[Am I on AI?](https://amionai.com)** – Simple checker that shows how often ChatGPT recommends your business and offers priority fixes; weekly trend emails.
 - **[AppearOnAI](https://appearonai.com)** – Action-oriented audit + playbook to boost site visibility inside ChatGPT, Claude & Gemini answers.
 - **[AthenaHQ](https://athenahq.ai)** – Analysed 3M+ AI responses; delivers free visibility report and a GEO playbook focused on mid-market SaaS.


### PR DESCRIPTION
Adding AI Visibility Monitor to the list. Open-source Python toolkit that tracks citations across ChatGPT, Claude, and Perplexity for a given domain.

Public URL for verification: https://github.com/WorkSmartAI-alt/ai-visibility-monitor
License: MIT
Maintained by: a solo consultant (Ignacio Lopez, Work-Smart.ai) using it in production for client AI visibility tracking work.

Distinguishing characteristic vs. existing entries on the list: this is one of the few open-source, self-hosted options. Most existing tools on the list are hosted SaaS.