### PR TITLE
Add AI Crawler Robots.txt Builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ These can help you ride the AI wave to success rather than drown in it.
 
 - **[AiCarma](https://aicarma.com)** – Daily *Visibility Score* and weekly email reports showing how Google AI Overviews, ChatGPT & Perplexity talk about your brand; 5-minute setup and flat $29 / mo after a 14-day trial.
 - **[AI Monitor](https://getaimonitor.com/)** – AI Monitor is the world’s first [open-source]([url](https://github.com/aio-guru/ai-monitor-first-open-source-free-ai-search-optimization-aio-answer-engine-optimization-aeo-tool/tree/main)) tool to track brand mentions in AI answers. See how ChatGPT, Google AI Overview, and Perplexity talk about you—and how you stack up against competitors.
+- **[AI Crawler Robots.txt Builder](https://ai-crawler-robots-builder.vercel.app/)** – Free, open-source, client-side robots.txt generator and checker for GPTBot, ClaudeBot, Google-Extended, PerplexityBot, and custom AI crawler tokens; runs with no login, tracking, cookies, uploads, or external scripts.
 - **[AI Rank Tracker](https://airank.dejan.ai)** – DejanSEO’s experimental tool mining language-association graphs to show which entities LLMs most connect to your brand.
 - **[Am I on AI?](https://amionai.com)** – Simple checker that shows how often ChatGPT recommends your business and offers priority fixes; weekly trend emails.
 - **[AppearOnAI](https://appearonai.com)** – Action-oriented audit + playbook to boost site visibility inside ChatGPT, Claude & Gemini answers.


### PR DESCRIPTION
Adds AI Crawler Robots.txt Builder to the GEO tools list.

Fit notes:
- Free public utility for AI crawler access control, a technical GEO/AEO workflow.
- Open-source and client-side only.
- No signup, tracking, cookies, uploads, or external scripts.

Public URL: https://ai-crawler-robots-builder.vercel.app/
Source: https://github.com/Turner-Levey/ai-crawler-robots-builder