### PR TITLE
Add Revolead (GEO + B2B lead generation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ These can help you ride the AI wave to success rather than drown in it.
 - **[Promptwatch](https://aitools.inc/tools/promptwatch)** – Tracks brand mentions, pinpoints “answer gaps” and suggests new content topics to fill them.
 - **[Quno.ai](https://quno.ai)** – Brand-visibility scorecard, prompt-library tester and AI-SEO writer rolled into one; free tier available.
 - **[Rankscale.ai](https://rankscale.ai)** – Generative-Engine-Optimisation suite with rank tracking, competitive gaps and a handy AEO/GEO tactics blog.
+- **[Revolead](https://revolead.ai)** – Done-for-you GEO and B2B lead generation: maps buyer-intent prompts, builds the pages that win answers in ChatGPT, Perplexity, Gemini & Google AI Overviews, then ties AI visibility back to qualified enquiries.
 - **[Scalenut](https://www.scalenut.com/)** – AI SEO and content suite with generative search optimization features.
 - **[Scrunch AI — Insights Platform](https://scrunchai.com/platform/insights/)** – Explains how AI interprets each page, then gives step-by-step fixes to lift rankings; SOC-2 enterprise option.
 - **[Search Visibility](https://search-visibility.ai)** – Tracks brand mentions across ChatGPT, Gemini, Claude, and more AI models.


### PR DESCRIPTION
Adding **Revolead** (https://revolead.ai) to the list.

Revolead is a done-for-you Generative Engine Optimization (GEO) and B2B lead generation service: it maps buyer-intent prompts, builds and improves the pages that should win answers in ChatGPT, Perplexity, Gemini and Google AI Overviews, and connects AI visibility back to qualified commercial enquiries.

Inserted alphabetically between Rankscale.ai and Scalenut. Public URL included for verification per the contribution note.