### PR TITLE
Add AI Crawler Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ These can help you ride the AI wave to success rather than drown in it.
 > **Quick note** – Pricing and features are vendor-reported snapshots; always double-check before you commit.
 
 - **[AiCarma](https://aicarma.com)** – Daily *Visibility Score* and weekly email reports showing how Google AI Overviews, ChatGPT & Perplexity talk about your brand; 5-minute setup and flat $29 / mo after a 14-day trial.
+- **[AI Crawler Bots](https://github.com/TryGeoSuite/ai-crawler-bots)** – Open-source, zero-dependency CLI and GitHub Action that audits your robots.txt against a curated list of AI crawler user-agents (GPTBot, ClaudeBot, PerplexityBot, Google-Extended, Bytespider), computes an AI-visibility score, tests live bot reachability, and reads access logs to confirm which AI bots actually crawled.
 - **[AI Monitor](https://getaimonitor.com/)** – AI Monitor is the world’s first [open-source]([url](https://github.com/aio-guru/ai-monitor-first-open-source-free-ai-search-optimization-aio-answer-engine-optimization-aeo-tool/tree/main)) tool to track brand mentions in AI answers. See how ChatGPT, Google AI Overview, and Perplexity talk about you—and how you stack up against competitors.
 - **[AI Rank Tracker](https://airank.dejan.ai)** – DejanSEO’s experimental tool mining language-association graphs to show which entities LLMs most connect to your brand.
 - **[Am I on AI?](https://amionai.com)** – Simple checker that shows how often ChatGPT recommends your business and offers priority fixes; weekly trend emails.


### PR DESCRIPTION
Hi, thanks for maintaining this list! I'd like to add **AI Crawler Bots**, an open-source, zero-dependency Node CLI and GitHub Action that audits your robots.txt against a curated list of AI crawler user-agents (GPTBot, ClaudeBot, PerplexityBot, Google-Extended, Bytespider), computes an AI-visibility score, tests live bot reachability, and reads access logs to confirm which AI bots actually crawled.

- Repo: https://github.com/TryGeoSuite/ai-crawler-bots
- npm: `@geosuite/ai-crawler-bots` (MIT)

The entry follows the list's existing format (**bold title** + en-dash description) and is inserted in the correct alphabetical position.

CONTRIBUTING checklist:
- One tool per PR
- GEO/AEO relevant (helps ensure AI engines can crawl/index your site)
- Capitalized title
- Alphabetical placement
- Not a duplicate