### PR TITLE
Add Revenue Grader

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ These can help you ride the AI wave to success rather than drown in it.
 - **[Promptwatch](https://aitools.inc/tools/promptwatch)** – Tracks brand mentions, pinpoints “answer gaps” and suggests new content topics to fill them.
 - **[Quno.ai](https://quno.ai)** – Brand-visibility scorecard, prompt-library tester and AI-SEO writer rolled into one; free tier available.
 - **[Rankscale.ai](https://rankscale.ai)** – Generative-Engine-Optimisation suite with rank tracking, competitive gaps and a handy AEO/GEO tactics blog.
+- **[Revenue Grader](https://getrevenuegrader.com)** – Free page-level checker that scores whether ChatGPT, Claude and Perplexity would cite a URL, with nine subscores and concrete fixes; no signup for the first scan.
 - **[Scalenut](https://www.scalenut.com/)** – AI SEO and content suite with generative search optimization features.
 - **[Scrunch AI — Insights Platform](https://scrunchai.com/platform/insights/)** – Explains how AI interprets each page, then gives step-by-step fixes to lift rankings; SOC-2 enterprise option.
 - **[Search Visibility](https://search-visibility.ai)** – Tracks brand mentions across ChatGPT, Gemini, Claude, and more AI models.


### PR DESCRIPTION
Adds Revenue Grader: a free page-level tool that scores whether ChatGPT, Claude, and Perplexity would cite a URL (AEO/GEO), returning nine subscores and concrete fixes. No signup for the first scan.

Matches the list format `[RESOURCE](LINK) - DESCRIPTION.` and is inserted alphabetically (after Rankscale.ai). Public URL for verification: https://getrevenuegrader.com